### PR TITLE
Added error handling when "ENOENT" thrown

### DIFF
--- a/nextjs-temp/src/app/page.tsx
+++ b/nextjs-temp/src/app/page.tsx
@@ -137,8 +137,15 @@ export default function Home() {
         } else {
           try {
             const errorResponse = JSON.parse(xhr.responseText);
-            setError(errorResponse.error || 'An error occurred during analysis');
-            setDebugInfo(errorResponse.details || null);
+            if (errorResponse.error === 'PDF cannot be processed') {
+              // Show toast message for PDF processing error
+              setError('PDF cannot be processed; Reasons: File may be password protected, is a scanned image or corrupt.');
+              // Clear files to allow new upload
+              setFiles([]);
+            } else {
+              setError(errorResponse.error || 'An error occurred during analysis');
+              setDebugInfo(errorResponse.details || null);
+            }
           } catch {
             setError('Failed to analyze document');
           }


### PR DESCRIPTION
If the error contains "enoent" is contained, then display a toast by coming back to the main page

## Description
If an error is thrown by the API call while uploading a file for analysis, it throws an "ENOENT" error, it returns to the main site

## Changes Made


## Testing
By uploading a scanned image file.

## Screenshots

## Checklist
- [x] Code follows project style guidelines
- [ ] Tests added/updated for new features
- [ ] Documentation updated
- [x] Security considerations addressed